### PR TITLE
feat: detached glass actions, root-level actions, and window-level actions prop

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,31 @@
+# Releasing
+
+Publishing is driven by the **Publish to npm** workflow
+(`.github/workflows/publish.yml`). It is triggered manually and reads the version from
+`package.json`: a formal version (`X.Y.Z`) publishes under the `latest` dist-tag, a
+pre-release (`X.Y.Z-dev.N`) under `dev`.
+
+## Steps
+
+1. **Bump the version** in `package.json` and merge it to `main`:
+
+   ```bash
+   npm version 0.3.4 --no-git-tag-version                 # formal
+   npm version prepatch --preid=dev --no-git-tag-version  # dev pre-release
+   ```
+
+2. **Run the workflow** — Actions tab → **Publish to npm** → **Run workflow** on `main`.
+   It fails if the `vX.Y.Z` tag already exists, so bump first.
+
+3. **Approve** the `PUBLISH` environment gate. On approval the workflow builds, publishes
+   to npm, pushes the `vX.Y.Z` tag, and (for formal releases) generates release notes.
+
+## Reviewer's job
+
+`pnpm publish` ships whatever `package.json` says, so before approving, confirm:
+
+- the run targets `main` at the intended release commit;
+- `package.json`'s `version` matches the version you mean to ship;
+- routing is correct — `X.Y.Z` → `latest`, `X.Y.Z-dev.N` → `dev`.
+
+Otherwise reject, fix `package.json`, and re-run.

--- a/dev/actions.tsx
+++ b/dev/actions.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import {
+  Window,
+  DEFAULT_GLASS_ACTIONS,
+  DEFAULT_DETACHED_GLASS_ACTIONS,
+} from '../src'
+
+
+export default function App() {
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Actions</h2>
+      <Window
+        id="root"
+        width={444}
+        height={333}
+        actions={[DEFAULT_GLASS_ACTIONS[0], DEFAULT_GLASS_ACTIONS[2]]}
+        panes={[
+          {
+            size: 0.4,
+          },
+          {
+            children: [
+              {
+                size: 0.5,
+                position: 'top',
+              },
+            ],
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/dev/bwin-native.ts
+++ b/dev/bwin-native.ts
@@ -1,4 +1,4 @@
-import { BinaryWindow, BUILTIN_ACTIONS } from 'bwin'
+import { BinaryWindow, DEFAULT_GLASS_ACTIONS } from 'bwin'
 
 const settings: ConfigRoot = {
   width: 444,
@@ -21,7 +21,7 @@ const settings: ConfigRoot = {
             }
           },
         },
-        ...BUILTIN_ACTIONS,
+        ...DEFAULT_GLASS_ACTIONS,
       ],
     },
     {

--- a/dev/custom-action.tsx
+++ b/dev/custom-action.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Window, BUILTIN_ACTIONS } from '../src'
+import { Window, DEFAULT_GLASS_ACTIONS } from '../src'
 
 export default function App() {
   return (
@@ -25,7 +25,7 @@ export default function App() {
                   }
                 },
               },
-              ...BUILTIN_ACTIONS,
+              ...DEFAULT_GLASS_ACTIONS,
             ],
           },
         ]}

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import './index.css'
 
 const links = [
+  'actions',
   'adhoc',
   'update-pane-content',
   'update-pane-content-zustand',

--- a/examples/dashboard/src/App.tsx
+++ b/examples/dashboard/src/App.tsx
@@ -1,8 +1,16 @@
 import { useRef, useState } from 'react'
-import { Window, BUILTIN_ACTIONS } from 'react-bwin'
+import { Window } from 'react-bwin'
 import 'react-bwin/react-bwin.css'
 
-function StatCard({ label, value, trend }: { label: string; value: string; trend: string }) {
+function StatCard({
+  label,
+  value,
+  trend,
+}: {
+  label: string
+  value: string
+  trend: string
+}) {
   const isUp = trend.startsWith('+')
   return (
     <div className="stat-card">
@@ -34,15 +42,18 @@ function BarChart() {
     { label: 'Sat', value: 55 },
     { label: 'Sun', value: 40 },
   ]
-  const max = Math.max(...data.map(d => d.value))
+  const max = Math.max(...data.map((d) => d.value))
 
   return (
     <div className="chart-container">
       <div className="chart-title">Weekly Traffic</div>
       <div className="bar-chart">
-        {data.map(d => (
+        {data.map((d) => (
           <div key={d.label} className="bar-col">
-            <div className="bar" style={{ height: `${(d.value / max) * 100}%` }} />
+            <div
+              className="bar"
+              style={{ height: `${(d.value / max) * 100}%` }}
+            />
             <div className="bar-label">{d.label}</div>
           </div>
         ))}
@@ -103,7 +114,7 @@ function DonutChart() {
       <div className="chart-title">Traffic Sources</div>
       <div className="donut-wrapper">
         <svg viewBox="0 0 100 100" className="donut-svg">
-          {segments.map(seg => {
+          {segments.map((seg) => {
             const dash = (seg.pct / 100) * circumference
             const gap = circumference - dash
             const currentOffset = offset
@@ -111,7 +122,9 @@ function DonutChart() {
             return (
               <circle
                 key={seg.label}
-                cx="50" cy="50" r={radius}
+                cx="50"
+                cy="50"
+                r={radius}
                 fill="none"
                 stroke={seg.color}
                 strokeWidth="12"
@@ -122,7 +135,7 @@ function DonutChart() {
           })}
         </svg>
         <div className="donut-legend">
-          {segments.map(seg => (
+          {segments.map((seg) => (
             <div key={seg.label} className="legend-item">
               <span className="legend-dot" style={{ background: seg.color }} />
               {seg.label} ({seg.pct}%)
@@ -146,10 +159,20 @@ function DataTable() {
     <div className="data-table-wrapper">
       <div className="chart-title">Top Pages</div>
       <table className="data-table">
-        <thead><tr><th>Page</th><th>Views</th><th>Bounce</th></tr></thead>
+        <thead>
+          <tr>
+            <th>Page</th>
+            <th>Views</th>
+            <th>Bounce</th>
+          </tr>
+        </thead>
         <tbody>
-          {rows.map(r => (
-            <tr key={r.page}><td>{r.page}</td><td>{r.views}</td><td>{r.bounce}</td></tr>
+          {rows.map((r) => (
+            <tr key={r.page}>
+              <td>{r.page}</td>
+              <td>{r.views}</td>
+              <td>{r.bounce}</td>
+            </tr>
           ))}
         </tbody>
       </table>
@@ -208,7 +231,7 @@ export default function App() {
     windowRef.current?.addPane('stats', {
       position: 'bottom',
       size: 0.4,
-      title: `${widgetOptions.find(w => w.id === selectedWidget)?.label} #${counter}`,
+      title: `${widgetOptions.find((w) => w.id === selectedWidget)?.label} #${counter}`,
       content: <Widget />,
       draggable: true,
       droppable: true,
@@ -223,13 +246,17 @@ export default function App() {
           <select
             className="widget-select"
             value={selectedWidget}
-            onChange={e => setSelectedWidget(e.target.value)}
+            onChange={(e) => setSelectedWidget(e.target.value)}
           >
-            {widgetOptions.map(w => (
-              <option key={w.id} value={w.id}>{w.label}</option>
+            {widgetOptions.map((w) => (
+              <option key={w.id} value={w.id}>
+                {w.label}
+              </option>
             ))}
           </select>
-          <button className="add-btn" onClick={handleAddWidget}>+ Add Widget</button>
+          <button className="add-btn" onClick={handleAddWidget}>
+            + Add Widget
+          </button>
         </div>
       </header>
       <div className="dashboard-body">
@@ -256,7 +283,6 @@ export default function App() {
                   size: '50%',
                   title: 'Traffic',
                   content: <BarChart />,
-                  actions: [...BUILTIN_ACTIONS],
                   draggable: true,
                   droppable: true,
                 },
@@ -269,7 +295,6 @@ export default function App() {
                       size: '55%',
                       title: 'Sources',
                       content: <DonutChart />,
-                      actions: [...BUILTIN_ACTIONS],
                       draggable: true,
                       droppable: true,
                     },
@@ -278,7 +303,6 @@ export default function App() {
                       position: 'bottom',
                       title: 'Activity',
                       content: <ActivityList />,
-                      actions: [...BUILTIN_ACTIONS],
                       draggable: true,
                       droppable: true,
                     },

--- a/examples/ide/src/App.tsx
+++ b/examples/ide/src/App.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Window, BUILTIN_ACTIONS } from 'react-bwin'
+import { Window, DEFAULT_GLASS_ACTIONS } from 'react-bwin'
 import 'react-bwin/react-bwin.css'
 
 const files = [
@@ -116,6 +116,9 @@ export default function App() {
           ref={windowRef}
           fitContainer
           theme="dark"
+          actions={
+            [DEFAULT_GLASS_ACTIONS[2]]
+          }
           panes={[
             {
               id: 'sidebar',
@@ -140,7 +143,6 @@ export default function App() {
                       size: '50%',
                       title: 'App.tsx',
                       content: <Editor filename="App.tsx" />,
-                      actions: [],
                       draggable: true,
                       droppable: true,
                     },
@@ -150,7 +152,6 @@ export default function App() {
                       size: '50%',
                       title: 'main.tsx',
                       content: <Editor filename="main.tsx" />,
-                      actions: [BUILTIN_ACTIONS[2]],
                       draggable: true,
                       droppable: true,
                     },
@@ -162,7 +163,6 @@ export default function App() {
                   size: '30%',
                   title: 'Terminal',
                   content: <Terminal />,
-                  actions: [BUILTIN_ACTIONS[2]],
                   draggable: true,
                   droppable: true,
                 },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.3.3",
+    "bwin": "0.4.0",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.4.0",
+    "bwin": "0.4.1",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.4.1
+        version: 0.4.1
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.4.0:
-    resolution: {integrity: sha512-0nmWgQOLDtY5YLKkIlWFIpIZ7PrzX6H1WrBrD31s65Jhcgw9ivPHpR7IYpSupCb9afdwU2AdCdPvLSqrb6pZ4w==}
+  bwin@0.4.1:
+    resolution: {integrity: sha512-8P5hoe0DiDZeW56RbNoa71Njfm6U85qBlNcx68p4kVclkh2P0vz0+bRc84OZxnzRME96uvqvk3v1WysNcIIC0g==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.4.0: {}
+  bwin@0.4.1: {}
 
   csstype@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^24.12.4
-        version: 24.12.4
+        version: 24.13.1
       '@types/react':
         specifier: ^16.14.62
         version: 16.14.70
@@ -19,10 +19,10 @@ importers:
         version: 16.9.25(@types/react@16.14.70)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@24.12.4))
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.3.3
-        version: 0.3.3
+        specifier: 0.4.0
+        version: 0.4.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -40,7 +40,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@24.12.4)
+        version: 8.0.16(@types/node@24.13.1)
       zustand:
         specifier: ^4.5.5
         version: 4.5.7(@types/react@16.14.70)(react@16.14.0)
@@ -59,19 +59,19 @@ importers:
     devDependencies:
       '@types/react':
         specifier: ^18.3.12
-        version: 18.3.29
+        version: 18.3.31
       '@types/react-dom':
         specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.29)
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@24.12.4))
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@24.12.4)
+        version: 8.0.16(@types/node@24.13.1)
 
   examples/ide:
     dependencies:
@@ -87,19 +87,19 @@ importers:
     devDependencies:
       '@types/react':
         specifier: ^18.3.12
-        version: 18.3.29
+        version: 18.3.31
       '@types/react-dom':
         specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.29)
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@24.12.4))
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13(@types/node@24.12.4)
+        version: 8.0.16(@types/node@24.13.1)
 
 packages:
 
@@ -118,100 +118,100 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.130.0':
-    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
-    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
-    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
-    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
-    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
-    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -222,8 +222,8 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -241,8 +241,8 @@ packages:
   '@types/react@16.14.70':
     resolution: {integrity: sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==}
 
-  '@types/react@18.3.29':
-    resolution: {integrity: sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==}
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@types/scheduler@0.16.8':
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.3.3:
-    resolution: {integrity: sha512-CAMB7EOGHemfrQbHRGfHe6ndsiFrDMwN+OY8NAi0pRWjdj5NhMzsk+P0D+1J/pkmWPFqrpeNmULhqdKblKda/A==}
+  bwin@0.4.0:
+    resolution: {integrity: sha512-0nmWgQOLDtY5YLKkIlWFIpIZ7PrzX6H1WrBrD31s65Jhcgw9ivPHpR7IYpSupCb9afdwU2AdCdPvLSqrb6pZ4w==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -414,8 +414,8 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  rolldown@1.0.1:
-    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -429,8 +429,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tslib@2.8.1:
@@ -441,16 +441,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vite@8.0.13:
-    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -532,55 +532,55 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@oxc-project/types@0.130.0': {}
+  '@oxc-project/types@0.133.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.1':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.1':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -590,9 +590,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/node@24.12.4':
+  '@types/node@24.13.1':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.18.2
 
   '@types/prop-types@15.7.15': {}
 
@@ -600,9 +600,9 @@ snapshots:
     dependencies:
       '@types/react': 16.14.70
 
-  '@types/react-dom@18.3.7(@types/react@18.3.29)':
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 18.3.29
+      '@types/react': 18.3.31
 
   '@types/react@16.14.70':
     dependencies:
@@ -610,19 +610,19 @@ snapshots:
       '@types/scheduler': 0.16.8
       csstype: 3.2.3
 
-  '@types/react@18.3.29':
+  '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/scheduler@0.16.8': {}
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@24.12.4))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@24.12.4)
+      vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.3.3: {}
+  bwin@0.4.0: {}
 
   csstype@3.2.3: {}
 
@@ -738,26 +738,26 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  rolldown@1.0.1:
+  rolldown@1.0.3:
     dependencies:
-      '@oxc-project/types': 0.130.0
+      '@oxc-project/types': 0.133.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.1
-      '@rolldown/binding-darwin-arm64': 1.0.1
-      '@rolldown/binding-darwin-x64': 1.0.1
-      '@rolldown/binding-freebsd-x64': 1.0.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
-      '@rolldown/binding-linux-s390x-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-musl': 1.0.1
-      '@rolldown/binding-openharmony-arm64': 1.0.1
-      '@rolldown/binding-wasm32-wasi': 1.0.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.1
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   scheduler@0.19.1:
     dependencies:
@@ -770,7 +770,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -780,21 +780,21 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.18.2: {}
 
   use-sync-external-store@1.6.0(react@16.14.0):
     dependencies:
       react: 16.14.0
 
-  vite@8.0.13(@types/node@24.12.4):
+  vite@8.0.16(@types/node@24.13.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       fsevents: 2.3.3
 
   zustand@4.5.7(@types/react@16.14.70)(react@16.14.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,4 @@ packages:
 allowBuilds:
   esbuild: true
 
-minimumReleaseAgeExclude:
-  - bwin@0.3.3
+minimumReleaseAge: 0

--- a/src/Pane.tsx
+++ b/src/Pane.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect } from 'react'
-import { DEFAULT_GLASS_ACTIONS } from 'bwin'
 
 export default function Pane({
   sash,
@@ -17,7 +16,7 @@ export default function Pane({
 
   const actions =
     sash.store?.actions === undefined
-      ? DEFAULT_GLASS_ACTIONS
+      ? bwin.actions[0]
       : Array.isArray(sash.store.actions)
         ? sash.store.actions
         : []

--- a/src/Pane.tsx
+++ b/src/Pane.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react'
-import { BUILTIN_ACTIONS } from 'bwin'
+import { DEFAULT_GLASS_ACTIONS } from 'bwin'
 
 export default function Pane({
   sash,
@@ -17,7 +17,7 @@ export default function Pane({
 
   const actions =
     sash.store?.actions === undefined
-      ? BUILTIN_ACTIONS
+      ? DEFAULT_GLASS_ACTIONS
       : Array.isArray(sash.store.actions)
         ? sash.store.actions
         : []

--- a/src/Pane.tsx
+++ b/src/Pane.tsx
@@ -33,9 +33,7 @@ export default function Pane({
         <bw-glass-header
           can-drag={sash.store?.draggable === false ? 'false' : 'true'}
         >
-          {sash.store?.title && (
-            <bw-glass-title>{sash.store.title}</bw-glass-title>
-          )}
+          <bw-glass-title>{sash.store?.title}</bw-glass-title>
           {actions.length > 0 && (
             <bw-glass-action-container>
               {actions.map((action: any, key: number) => {

--- a/src/bwin.d.ts
+++ b/src/bwin.d.ts
@@ -1,5 +1,7 @@
 declare module 'bwin' {
   export const BUILTIN_ACTIONS: Action[]
+  export const DEFAULT_GLASS_ACTIONS: Action[]
+  export const DEFAULT_DETACHED_GLASS_ACTIONS: Action[]
   export const BinaryWindow: BinaryWindow
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,7 @@
 declare module 'react-bwin' {
   export const BUILTIN_ACTIONS: Action[]
+  export const DEFAULT_GLASS_ACTIONS: Action[]
+  export const DEFAULT_DETACHED_GLASS_ACTIONS: Action[]
   export const Window: React.ForwardRefExoticComponent<
     WindowProps & React.RefAttributes<WindowHandle>
   >
@@ -63,6 +65,7 @@ declare global {
     height?: number
     fitContainer?: boolean
     theme?: string
+    actions?: Actions | [Actions, Actions?]
     title?: React.ReactNode
     content?: React.ReactNode
     children?: ConfigNode[]

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -78,6 +78,7 @@ declare global {
     containerElement: HTMLElement
     sillElement: HTMLElement
     theme: string
+    actions: [Action[], Action[]]
     mount(container: HTMLElement): void
     enableFeatures(): void
     fit(): void

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
-export { BUILTIN_ACTIONS } from 'bwin'
+export { BUILTIN_ACTIONS, DEFAULT_GLASS_ACTIONS, DEFAULT_DETACHED_GLASS_ACTIONS } from 'bwin'
 export { default as Window } from './Window'
 export { version } from '../package.json'


### PR DESCRIPTION
## Summary

Adds support for bwin's detached-glass action feature, root-level window actions, and wires the `<Window actions>` prop through to panes.

- Export `DEFAULT_GLASS_ACTIONS` and `DEFAULT_DETACHED_GLASS_ACTIONS` (from `bwin`) alongside the existing `BUILTIN_ACTIONS`
- Add root-level `actions` to `ConfigRoot`, typed `Actions | [Actions, Actions?]` (attached / detached glass)
- Pane actions now fall back to the window's normalized actions (`bwin.actions[0]`) instead of `BUILTIN_ACTIONS`, mirroring bwin's `onPaneCreate` so the `<Window actions>` prop takes effect
- Always render `<bw-glass-title>` (even when empty) so the title element is consistently present
- Add a `dev/actions` page to exercise window-level actions
- Upgrade the `bwin` dependency

## Notes

- `examples/dashboard/src/App.tsx` also picked up prettier-style reformatting (arrow-param parens, multi-line JSX) in the same change.