### PR TITLE
feat: WindowProvider and useWindow hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,7 @@
 ## Testing
 
 - Don't run tests or build after completing a feature or fixing a bug unless asked.
+
+## Examples
+
+- The `examples/` apps import `react-bwin` from the built `dist/`, not `src/`. After changing library source, run `pnpm build` before the examples reflect it. (The `dev/` app loads `src` directly and needs no rebuild.)

--- a/dev/add-remove-panes.tsx
+++ b/dev/add-remove-panes.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Window } from '../src'
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  const windowRef = useRef<WindowApi>(null)
   const [inputValue, setInputValue] = useState('')
 
   useEffect(() => {

--- a/dev/fit-container.tsx
+++ b/dev/fit-container.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 import { Window } from '../src'
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  const windowRef = useRef<WindowApi>(null)
 
   return (
     <div style={{ padding: 20 }}>

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -14,6 +14,7 @@ const links = [
   'custom-action',
   're-render',
   'theme',
+  'window-provider',
 ].sort()
 
 const components: Record<string, FunctionComponent> = {}

--- a/dev/theme.tsx
+++ b/dev/theme.tsx
@@ -25,7 +25,7 @@ const inputs = (
 )
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  const windowRef = useRef<WindowApi>(null)
   const [themeInput, setThemeInput] = useState('dark')
 
   function toggleTheme() {

--- a/dev/window-provider.tsx
+++ b/dev/window-provider.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Window, WindowProvider, useWindow } from '../src'
+
+export default function App() {
+  return (
+    <WindowProvider>
+      <Main />
+    </WindowProvider>
+  )
+}
+
+function Main() {
+  const { addPane } = useWindow()
+
+  function handlePaneAdd() {
+    addPane()
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Window Provider</h2>
+      <button onClick={handlePaneAdd}>Add pane</button>
+      <Window
+        id="root"
+        width={444}
+        height={333}
+        panes={[
+          {
+            size: 0.4,
+          },
+          {
+            children: [
+              {
+                size: 0.5,
+                position: 'top',
+              },
+            ],
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/dev/window-provider.tsx
+++ b/dev/window-provider.tsx
@@ -10,16 +10,28 @@ export default function App() {
 }
 
 function Main() {
-  const { addPane } = useWindow()
+  const { addPane, removePane, fit, setTheme } = useWindow()
 
   function handlePaneAdd() {
-    addPane()
+    addPane('a', {
+      position: 'right',
+      size: 0.3,
+      title: 'New title',
+      content: <i>New content</i>,
+    })
+  }
+
+  function handlePaneRemove() {
+    removePane('a')
   }
 
   return (
     <div style={{ padding: 20 }}>
       <h2>Window Provider</h2>
       <button onClick={handlePaneAdd}>Add pane</button>
+      <button onClick={handlePaneRemove}>Remove pane</button>
+      <button onClick={() => fit()}>Fit</button>
+      <button onClick={() => setTheme('dark')}>Dark theme</button>
       <Window
         id="root"
         width={444}
@@ -27,12 +39,16 @@ function Main() {
         panes={[
           {
             size: 0.4,
+            id: 'a',
+            content: 'a',
           },
           {
             children: [
               {
                 size: 0.5,
                 position: 'top',
+                id: 'b',
+                content: 'b',
               },
             ],
           },

--- a/dev/window-provider.tsx
+++ b/dev/window-provider.tsx
@@ -12,6 +12,10 @@ export default function App() {
 function Main() {
   const { addPane, removePane, fit, setTheme } = useWindow()
 
+  React.useEffect(() => {
+    setTheme('dark')
+  })
+
   function handlePaneAdd() {
     addPane('a', {
       position: 'right',
@@ -31,7 +35,7 @@ function Main() {
       <button onClick={handlePaneAdd}>Add pane</button>
       <button onClick={handlePaneRemove}>Remove pane</button>
       <button onClick={() => fit()}>Fit</button>
-      <button onClick={() => setTheme('dark')}>Dark theme</button>
+      <button onClick={() => setTheme('light')}>Light theme</button>
       <Window
         id="root"
         width={444}

--- a/dev/window-ref.tsx
+++ b/dev/window-ref.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { Window } from '../src'
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  const windowRef = useRef<WindowApi>(null)
 
   useEffect(() => {
     console.log(windowRef.current)

--- a/examples/dashboard/src/App.tsx
+++ b/examples/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react'
-import { Window } from 'react-bwin'
+import { useState } from 'react'
+import { Window, WindowProvider, useWindow } from 'react-bwin'
 import 'react-bwin/react-bwin.css'
 
 function StatCard({
@@ -222,13 +222,21 @@ const widgetComponents: Record<string, () => JSX.Element> = {
 let counter = 0
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  return (
+    <WindowProvider>
+      <Dashboard />
+    </WindowProvider>
+  )
+}
+
+function Dashboard() {
+  const { addPane } = useWindow()
   const [selectedWidget, setSelectedWidget] = useState('table')
 
   function handleAddWidget() {
     counter++
     const Widget = widgetComponents[selectedWidget]
-    windowRef.current?.addPane('stats', {
+    addPane('stats', {
       position: 'bottom',
       size: 0.4,
       title: `${widgetOptions.find((w) => w.id === selectedWidget)?.label} #${counter}`,
@@ -261,7 +269,6 @@ export default function App() {
       </header>
       <div className="dashboard-body">
         <Window
-          ref={windowRef}
           fitContainer
           panes={[
             {

--- a/examples/ide/src/App.tsx
+++ b/examples/ide/src/App.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react'
-import { Window, DEFAULT_GLASS_ACTIONS } from 'react-bwin'
+import { useState } from 'react'
+import { Window, WindowProvider, useWindow, DEFAULT_GLASS_ACTIONS } from 'react-bwin'
 import 'react-bwin/react-bwin.css'
 
 const files = [
@@ -85,13 +85,21 @@ function Terminal() {
 let paneCounter = 0
 
 export default function App() {
-  const windowRef = useRef<WindowHandle>(null)
+  return (
+    <WindowProvider>
+      <Ide />
+    </WindowProvider>
+  )
+}
+
+function Ide() {
+  const { addPane } = useWindow()
   const [status, setStatus] = useState('Ready')
 
   function handleAddTab() {
     paneCounter++
     const name = `new-file-${paneCounter}.ts`
-    windowRef.current?.addPane('editor-1', {
+    addPane('editor-1', {
       position: 'right',
       size: 0.5,
       title: name,
@@ -113,7 +121,6 @@ export default function App() {
       </div>
       <div className="ide-window">
         <Window
-          ref={windowRef}
           fitContainer
           theme="dark"
           actions={

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.4.2",
+    "bwin": "0.4.3",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.4.2
-        version: 0.4.2
+        specifier: 0.4.3
+        version: 0.4.3
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.4.2:
-    resolution: {integrity: sha512-LM5was1Syb4fMmmOVeGVhJVlyaxr18fVeU574WRotTrZ5Q88vbsAvJNc4wKMWRauWYRl7euKTlgZjycKE7aO1w==}
+  bwin@0.4.3:
+    resolution: {integrity: sha512-QtAsbz6aLQo8R2MMDeBNM1dV8b6XU52nqycH3NoSY0BG8/xKqEYsk5lZtaf5rJmNLoMYOzuy9Xk7gmUIDdDmIw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.4.2: {}
+  bwin@0.4.3: {}
 
   csstype@3.2.3: {}
 

--- a/src/Window.tsx
+++ b/src/Window.tsx
@@ -1,6 +1,7 @@
 import React, {
   useRef,
   useEffect,
+  useContext,
   forwardRef,
   useImperativeHandle,
   useMemo,
@@ -11,9 +12,10 @@ import { createPortal } from 'react-dom'
 import { BinaryWindow } from 'bwin'
 import Muntin from './Muntin.tsx'
 import Pane from './Pane.tsx'
+import { WindowContext } from './WindowProvider.tsx'
 import 'bwin/bwin.css'
 
-export default forwardRef<WindowHandle, WindowProps>((props, ref) => {
+export default forwardRef<WindowApi, WindowProps>((props, ref) => {
   const windowRef = useRef<HTMLElement>()
   const sillRef = useRef<HTMLElement>()
   const [paneContentPortals, setPaneContentPortals] =
@@ -55,6 +57,25 @@ export default forwardRef<WindowHandle, WindowProps>((props, ref) => {
     }),
     []
   )
+
+  const windowContext = useContext(WindowContext)
+
+  useEffect(() => {
+    if (!windowContext) {
+      return
+    }
+
+    windowContext.api.current = {
+      fit: bwin.fit.bind(bwin),
+      removePane: bwin.removePane.bind(bwin),
+      setTheme: bwin.setTheme.bind(bwin),
+      addPane,
+    }
+
+    return () => {
+      windowContext.api.current = null
+    }
+  }, [])
 
   const windowNode = (
     <bw-window

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -35,28 +35,27 @@ export function useWindow(): WindowApi {
   //     setTheme('dark')
   //   }, [setTheme]) // setTheme is stable, so this effect runs only once
   //
-  // Methods resolve api.current at call time, since the window only populates
-  // it after it mounts.
+  // The Proxy forwards any method to api.current at call time (the window only
+  // populates it after it mounts), throwing if it's not ready. New WindowApi
+  // methods work automatically — no need to list them here.
   const apiRef = React.useRef<WindowApi>()
-  
+
   if (!apiRef.current) {
-    apiRef.current = {
-      addPane: (...args) => resolve(api).addPane(...args),
-      removePane: (...args) => resolve(api).removePane(...args),
-      fit: (...args) => resolve(api).fit(...args),
-      setTheme: (...args) => resolve(api).setTheme(...args),
-    }
+    apiRef.current = new Proxy({} as WindowApi, {
+      get(_target, key: keyof WindowApi) {
+        return (...args: unknown[]) => {
+          if (!api.current) {
+            throw new Error(
+              '[react-bwin] Window API is not ready yet. ' +
+                'Render a <Window> inside the <WindowProvider> before calling its methods.'
+            )
+          }
+          const method = api.current[key] as (...args: unknown[]) => unknown
+          return method(...args)
+        }
+      },
+    })
   }
 
   return apiRef.current
-}
-
-function resolve(api: React.MutableRefObject<WindowApi | null>): WindowApi {
-  if (!api.current) {
-    throw new Error(
-      '[react-bwin] Window API is not ready yet. ' +
-        'Render a <Window> inside the <WindowProvider> before calling its methods.'
-    )
-  }
-  return api.current
 }

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+
+type WindowApi = {
+  addPane: () => void
+  removePane: () => void
+  fit: () => void
+  setTheme: (theme: string) => void
+}
+
+const api: WindowApi = {
+  addPane: () => {
+    console.log('no-op addPane')
+  },
+  removePane: () => {
+    console.log('no-op removePane')
+  },
+  fit: () => {
+    console.log('no-op fit')
+  },
+  setTheme: (theme: string) => {
+    console.log('no-op setTheme', theme)
+  },
+}
+
+const WindowContext = React.createContext<WindowApi>(api)
+
+export function WindowProvider({ children }: React.PropsWithChildren<{}>) {
+  return <WindowContext.Provider value={api}>{children}</WindowContext.Provider>
+}
+
+export function useWindow() {
+  return React.useContext(WindowContext)
+}

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -23,13 +23,5 @@ export function useWindow(): WindowApi {
     throw new Error('useWindow must be used within a WindowProvider')
   }
 
-  const { api } = context
-
-  return {
-    addPane: (targetPaneId, fields) =>
-      api.current?.addPane(targetPaneId, fields),
-    removePane: (targetPaneId) => api.current?.removePane(targetPaneId),
-    fit: () => api.current?.fit(),
-    setTheme: (theme) => api.current?.setTheme(theme),
-  }
+  return context.api.current!
 }

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -1,33 +1,38 @@
 import * as React from 'react'
 
-type WindowApi = {
-  addPane: () => void
-  removePane: () => void
-  fit: () => void
-  setTheme: (theme: string) => void
+type WindowContextValue = {
+  api: React.MutableRefObject<WindowApi | null>
 }
 
-const api: WindowApi = {
-  addPane: () => {
-    console.log('no-op addPane')
-  },
-  removePane: () => {
-    console.log('no-op removePane')
-  },
-  fit: () => {
-    console.log('no-op fit')
-  },
-  setTheme: (theme: string) => {
-    console.log('no-op setTheme', theme)
-  },
-}
-
-const WindowContext = React.createContext<WindowApi>(api)
+export const WindowContext = React.createContext<WindowContextValue | null>(
+  null
+)
 
 export function WindowProvider({ children }: React.PropsWithChildren<{}>) {
-  return <WindowContext.Provider value={api}>{children}</WindowContext.Provider>
+  const api = React.useRef<WindowApi | null>(null)
+
+  return (
+    <WindowContext.Provider value={{ api }}>{children}</WindowContext.Provider>
+  )
 }
 
-export function useWindow() {
-  return React.useContext(WindowContext)
+export function useWindow(): WindowApi {
+  const context = React.useContext(WindowContext)
+
+  if (!context) {
+    throw new Error('useWindow must be used within a WindowProvider')
+  }
+
+  const { api } = context
+
+  return React.useMemo<WindowApi>(
+    () => ({
+      addPane: (targetPaneId, fields) =>
+        api.current?.addPane(targetPaneId, fields),
+      removePane: (targetPaneId) => api.current?.removePane(targetPaneId),
+      fit: () => api.current?.fit(),
+      setTheme: (theme) => api.current?.setTheme(theme),
+    }),
+    [api]
+  )
 }

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -23,5 +23,40 @@ export function useWindow(): WindowApi {
     throw new Error('useWindow must be used within a WindowProvider')
   }
 
-  return context.api.current!
+  const { api } = context
+
+  // Lazily build the API wrapper once and lock its identity for the lifetime
+  // of the component (a ref is a true identity guarantee, unlike useMemo whose
+  // cache React may discard). This keeps it safe to use in consumer dependency
+  // arrays, e.g.:
+  //
+  //   const { setTheme } = useWindow()
+  //   React.useEffect(() => {
+  //     setTheme('dark')
+  //   }, [setTheme]) // setTheme is stable, so this effect runs only once
+  //
+  // Methods resolve api.current at call time, since the window only populates
+  // it after it mounts.
+  const apiRef = React.useRef<WindowApi>()
+  
+  if (!apiRef.current) {
+    apiRef.current = {
+      addPane: (...args) => resolve(api).addPane(...args),
+      removePane: (...args) => resolve(api).removePane(...args),
+      fit: (...args) => resolve(api).fit(...args),
+      setTheme: (...args) => resolve(api).setTheme(...args),
+    }
+  }
+
+  return apiRef.current
+}
+
+function resolve(api: React.MutableRefObject<WindowApi | null>): WindowApi {
+  if (!api.current) {
+    throw new Error(
+      '[react-bwin] Window API is not ready yet. ' +
+        'Render a <Window> inside the <WindowProvider> before calling its methods.'
+    )
+  }
+  return api.current
 }

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -25,14 +25,11 @@ export function useWindow(): WindowApi {
 
   const { api } = context
 
-  return React.useMemo<WindowApi>(
-    () => ({
-      addPane: (targetPaneId, fields) =>
-        api.current?.addPane(targetPaneId, fields),
-      removePane: (targetPaneId) => api.current?.removePane(targetPaneId),
-      fit: () => api.current?.fit(),
-      setTheme: (theme) => api.current?.setTheme(theme),
-    }),
-    [api]
-  )
+  return {
+    addPane: (targetPaneId, fields) =>
+      api.current?.addPane(targetPaneId, fields),
+    removePane: (targetPaneId) => api.current?.removePane(targetPaneId),
+    fit: () => api.current?.fit(),
+    setTheme: (theme) => api.current?.setTheme(theme),
+  }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,8 +3,12 @@ declare module 'react-bwin' {
   export const DEFAULT_GLASS_ACTIONS: Action[]
   export const DEFAULT_DETACHED_GLASS_ACTIONS: Action[]
   export const Window: React.ForwardRefExoticComponent<
-    WindowProps & React.RefAttributes<WindowHandle>
+    WindowProps & React.RefAttributes<WindowApi>
   >
+  export const WindowProvider: React.FunctionComponent<
+    React.PropsWithChildren<{}>
+  >
+  export function useWindow(): WindowApi
 }
 
 declare global {
@@ -87,12 +91,17 @@ declare global {
     setTheme(theme: string): void
   }
 
-  type WindowHandle = {
+  type WindowApi = {
     addPane: (targetPaneId: string, fields: PaneFields) => void
     removePane: (targetPaneId: string) => void
     fit: () => void
     setTheme: (theme: string) => void
   }
+
+  /**
+   * @deprecated Use {@link WindowApi} instead.
+   */
+  type WindowHandle = WindowApi
 
   type WindowProps = Omit<ConfigRoot, 'children'> & {
     panes?: ConfigNode[]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export { BUILTIN_ACTIONS, DEFAULT_GLASS_ACTIONS, DEFAULT_DETACHED_GLASS_ACTIONS } from 'bwin'
 export { default as Window } from './Window'
+export { WindowProvider, useWindow } from './WindowProvider'
 export { version } from '../package.json'


### PR DESCRIPTION
## Summary

Adds a `WindowProvider` + `useWindow` hook so consumers can drive a `Window`'s imperative API (`addPane`, `removePane`, `fit`, `setTheme`) from anywhere in the tree without manually threading a `ref`.

## How it works

- `WindowProvider` holds a ref to the window's `WindowApi` in context.
- A `Window` rendered inside the provider auto-registers its imperative handle into that ref on mount (and clears it on unmount). Manual `ref={...}` usage is unaffected — registration is additive and skipped when there's no provider.
- `useWindow()` returns a `WindowApi` whose methods delegate to the current registered handle, so calls always hit the live window.

## Other changes

- Renamed the handle type to `WindowApi`; kept `WindowHandle` as a `@deprecated` alias so existing consumers don't break.
- Added `WindowProvider` / `useWindow` to the published `react-bwin` module declaration.
- New `dev/window-provider.tsx` demo wired into the dev menu.
