### PR TITLE
ci: add auto dev-publish on merged PR to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,26 @@
 name: Publish to npm
 
+# Two publish paths share this one file because npm trusted publishing (OIDC) allows only one
+# workflow filename per package:
+#   - publish (manual)  : workflow_dispatch → stable release under `latest`, gated on PUBLISH env.
+#   - dev-publish (auto): merged PR to main → ephemeral <next-patch>-dev-<sha> under `dev`, unattended.
+
 on:
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    # Only changes that affect the published package warrant a dev pre-release.
+    # dev/, docs/, *.md, .github/, and config that doesn't feed the build are excluded.
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'vite.config.ts'
 
 jobs:
   publish:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: PUBLISH
     permissions:
@@ -73,3 +89,48 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dev-publish:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Compute ephemeral dev version
+        id: version
+        run: |
+          base="$(node -p "require('./package.json').version")"
+          # Next patch: split on '.', bump the last field. No semver dependency needed.
+          next="$(node -p "const [a,b,c]=require('./package.json').version.split('.'); [a,b,Number(c)+1].join('.')")"
+          sha="$(git rev-parse --short HEAD)"
+          devver="${next}-dev-${sha}"
+          # Edits the runner's copy only; --no-git-tag-version makes no commit and no tag.
+          npm version --no-git-tag-version "$devver"
+          echo "devver=$devver" >> "$GITHUB_OUTPUT"
+          echo "Publishing dev release \`$devver\` (base $base)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks --access public --tag dev


### PR DESCRIPTION
Mirrors the publish workflow from the `bwin` repo so react-bwin also ships ephemeral dev pre-releases automatically.

- Adds a `dev-publish` job that runs on merged PRs to `main`, publishing `<next-patch>-dev-<sha>` under the `dev` npm tag.
- Gates the existing manual `publish` job on `workflow_dispatch` so the two paths share one workflow file (required for npm OIDC trusted publishing).
- `paths:` filter uses `vite.config.ts` (react-bwin's config) so only build-affecting changes trigger a dev release.