### PR TITLE
docs: add Why section with smooth-resize pitch, move dev setup to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+This starts the dev server with internal test pages at `http://localhost:5173`.
+
+## Examples
+
+See the `examples/` directory for standalone apps. They depend on the library's built
+output, so build it first, then run an example (e.g. `dashboard`):
+
+```bash
+pnpm install
+pnpm build
+cd examples/dashboard
+pnpm dev
+```

--- a/README.md
+++ b/README.md
@@ -3,29 +3,26 @@
 [![Publish to npm](https://github.com/bhjsdev/react-bwin/actions/workflows/publish.yml/badge.svg)](https://github.com/bhjsdev/react-bwin/actions/workflows/publish.yml)
 [![npm version](https://img.shields.io/npm/v/react-bwin)](https://www.npmjs.com/package/react-bwin)
 
-A React-based tiling window manager featuring resizable panes, drag-and-drop, and more. Built on top of the [Binary Window](https://github.com/bhjsdev/bwin) library.
+A React tiling window manager featuring resizable panes, drag-and-drop, and more. Built on top of the [Binary Window](https://github.com/bhjsdev/bwin) library.
 
 [![A react-bwin tiling layout with resizable panes showing charts and a data table](docs/screenshot.png)](https://bhjsdev.github.io/bwin-docs?theme=dark)
 
-[Documentation](https://bhjsdev.github.io/bwin-docs/react/get-started)
+### Why react-bwin
 
-### Development
+Resizing and dragging stay smooth even with heavy content in every pane.
 
-```bash
-pnpm install
-pnpm dev
-```
+react-bwin renders the layout DOM once, then hands those nodes to the underlying [bwin](https://github.com/bhjsdev/bwin) engine, which drives interactions with **direct DOM writes** — a pointer move updates the geometry of just the two affected panes and never re-enters React's render cycle. So there's **no virtual-DOM diff on the drag path**: you keep React's component model for your pane content, and get native-feeling resize and drag for the layout.
 
-This starts the dev server with internal test pages at `http://localhost:5173`.
-
-### Examples
-
-See the `examples/` directory for standalone apps. They depend on the library's built
-output, so build it first, then run an example (e.g. `dashboard`):
+### Install
 
 ```bash
-pnpm install
-pnpm build
-cd examples/dashboard
-pnpm dev
+npm install react-bwin
 ```
+
+### Documentation
+
+Full guides, API reference, and live examples: [bhjsdev.github.io/bwin-docs](https://bhjsdev.github.io/bwin-docs/react/get-started)
+
+### Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development and how to run the examples.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ A React tiling window manager featuring resizable panes, drag-and-drop, and more
 
 ### Why react-bwin
 
-Resizing and dragging stay smooth even with heavy content in every pane.
-
-react-bwin renders the layout DOM once, then hands those nodes to the underlying [bwin](https://github.com/bhjsdev/bwin) engine, which drives interactions with **direct DOM writes** — a pointer move updates the geometry of just the two affected panes and never re-enters React's render cycle. So there's **no virtual-DOM diff on the drag path**: you keep React's component model for your pane content, and get native-feeling resize and drag for the layout.
+Resizing and dragging stay smooth even with heavy content in every pane. react-bwin renders the layout DOM once, then lets the underlying [bwin](https://github.com/bhjsdev/bwin) engine drive interactions with direct DOM writes — so there's **no virtual-DOM diff on the drag path**. Your pane content stays normal React.
 
 ### Install
 


### PR DESCRIPTION
## Summary
- Add a **Why react-bwin** section to the README: resizing/dragging stay smooth because the layout DOM is rendered once and then driven by bwin via direct DOM writes — no virtual-DOM diff on the drag path.
- Add an **Install** line.
- Move **Development** and **Examples** out of the README into a new `CONTRIBUTING.md`.

## Pitch accuracy
The "no VDOM diff on resize" claim was verified against the wrapper code:
- `Window.tsx` renders the layout DOM once (`useMemo(windowNode, [])`), then sets `bwin.windowElement`/`containerElement`/`sillElement` from refs and calls `bwin.enableFeatures()`.
- `Pane.tsx`/`Muntin.tsx` assign `sash.domNode = ref.current`, handing bwin the real nodes.
- bwin's document-level pointer listeners then write `.style` geometry directly on those nodes during resize/drag — React's reconciler never runs on that path. Pane *content* remains normal React.