### PR TITLE
fix: export WindowlessGlassApi and widen useWindow return type

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,7 +8,7 @@ declare module 'react-bwin' {
   export const WindowProvider: React.FunctionComponent<
     React.PropsWithChildren<{}>
   >
-  export function useWindow(): WindowApi
+  export function useWindow(): WindowApi & WindowlessGlassApi
 }
 
 declare global {
@@ -179,4 +179,5 @@ export {
   ConfigRoot,
   BinaryWindow,
   WindowProps,
+  WindowlessGlassApi,
 }


### PR DESCRIPTION
## Summary

The `react-bwin` module declaration advertised `useWindow(): WindowApi`, but the real hook returns `WindowApi & WindowlessGlassApi` (`WindowProvider.tsx:37`). Consumers importing from the package couldn't see the windowless-glass methods (`addWindowlessGlass` / `removeWindowlessGlass`) on the hook's return value.

- Widen the declared `useWindow` return type to `WindowApi & WindowlessGlassApi` to match the implementation.
- Export `WindowlessGlassApi` from the global block so it resolves for consumers and inside the module declaration.