### PR TITLE
fix: remove windowless glasses when WindowProvider unmounts

### DIFF
--- a/dev/detached-glass-unmount.tsx
+++ b/dev/detached-glass-unmount.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { Window, WindowProvider, useWindow } from '../src'
+
+// Repro/contrast for detached-glass teardown when the provider unmounts.
+// - Windowless glass is appended to document.body by a static BinaryWindow
+//   method, outside React's tree, so React can't remove it — useWindowlessGlass
+//   tears it down on unmount.
+// - A glass detached from a window (the ☐ action) is appended INSIDE the
+//   bw-window element, which React owns, so it's removed with the window.
+// Untick the checkbox with both kinds open: neither should linger.
+export default function App() {
+  const [mounted, setMounted] = React.useState(true)
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Detached glass — unmount cleanup</h2>
+      <ol>
+        <li>Open a windowless glass (try the modal too).</li>
+        <li>
+          Detach a pane from the window with its <b>☐</b> action.
+        </li>
+        <li>
+          Without closing anything, untick <b>Mount WindowProvider</b>.
+        </li>
+        <li>
+          Everything should disappear. Anything left on the page is an orphaned
+          glass.
+        </li>
+      </ol>
+      <label style={{ display: 'block', margin: '12px 0' }}>
+        <input
+          type="checkbox"
+          checked={mounted}
+          onChange={(e) => setMounted(e.target.checked)}
+        />{' '}
+        Mount WindowProvider
+      </label>
+      {mounted ? (
+        <WindowProvider>
+          <Main />
+        </WindowProvider>
+      ) : (
+        <i>Provider unmounted — no glass should remain on the page.</i>
+      )}
+    </div>
+  )
+}
+
+function Main() {
+  const { addWindowlessGlass } = useWindow()
+  const counter = React.useRef(0)
+
+  function handleOpen() {
+    const n = ++counter.current
+    addWindowlessGlass({
+      title: `Glass ${n}`,
+      content: <div style={{ padding: 8 }}>windowless {n}</div>,
+    })
+  }
+
+  function handleOpenModal() {
+    const n = ++counter.current
+    addWindowlessGlass({
+      modal: true,
+      title: `Modal glass ${n}`,
+      content: <div style={{ padding: 8 }}>modal {n}</div>,
+    })
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <button onClick={handleOpen}>Add windowless</button>
+        <button onClick={handleOpenModal}>Add modal</button>
+      </div>
+      <Window
+        width={444}
+        height={300}
+        panes={[
+          {
+            size: 0.5,
+            position: 'left',
+            title: 'Pane 1',
+            content: <div style={{ padding: 8 }}>Detach me with ☐</div>,
+          },
+          {
+            title: 'Pane 2',
+            content: <div style={{ padding: 8 }}>Detach me with ☐</div>,
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -17,6 +17,7 @@ const links = [
   'theme',
   'window-provider',
   'windowless-glass',
+  'detached-glass-unmount',
 ].sort()
 
 const components: Record<string, FunctionComponent> = {}

--- a/src/useWindowlessGlass.ts
+++ b/src/useWindowlessGlass.ts
@@ -1,24 +1,22 @@
-import { useState, ReactNode } from 'react'
+import { useEffect, useRef, useState, ReactNode } from 'react'
 import { BinaryWindow } from 'bwin'
 
-// Maps a windowless-glass id to the content node and the bw-glass-content it
-// portals into. Mirrors usePaneContentPortals, but keyed by glass id since a
-// windowless glass floats on document.body rather than living in a pane.
 export type WindowlessGlassPortalMap = Map<
   string,
   { node: ReactNode; container: HTMLElement }
 >
 
-// Owns the windowless-glass content portals and the add/remove functions.
-// addWindowlessGlass/removeWindowlessGlass are static on BinaryWindow (the glass
-// is detached from any window instance), so this hook needs no bwin instance.
 export default function useWindowlessGlass() {
   const [windowlessGlassPortals, setWindowlessGlassPortals] =
     useState<WindowlessGlassPortalMap>(() => new Map())
 
+  const liveGlassIdsRef = useRef<Set<string>>(new Set())
+
   function addWindowlessGlass(options: WindowlessGlassOptions = {}) {
     const { content, ...rest } = options
     const glassEl = BinaryWindow.addWindowlessGlass(rest)
+
+    liveGlassIdsRef.current.add(glassEl.id)
 
     if ('content' in options) {
       const contentEl = glassEl.querySelector('bw-glass-content')
@@ -44,6 +42,7 @@ export default function useWindowlessGlass() {
       windowlessGlassId,
       options
     )
+    liveGlassIdsRef.current.delete(windowlessGlassId)
 
     setWindowlessGlassPortals((prev) => {
       if (!prev.has(windowlessGlassId)) return prev
@@ -55,6 +54,20 @@ export default function useWindowlessGlass() {
 
     return removed
   }
+
+  // A windowless glass lives on document.body, outside React's tree. Without
+  // this, open glasses (and any modal backdrop) are orphaned on provider unmount.
+  useEffect(() => {
+    const liveGlassIds = liveGlassIdsRef.current
+
+    return () => {
+      liveGlassIds.forEach((id) =>
+        BinaryWindow.removeWindowlessGlass(id, { animateClose: false })
+      )
+      
+      liveGlassIds.clear()
+    }
+  }, [])
 
   return {
     windowlessGlassPortals,


### PR DESCRIPTION
## Problem

A windowless glass is appended directly to `document.body` by the static `BinaryWindow.addWindowlessGlass`, outside React's tree. `WindowProvider` only portals the glass *content* into it — it never owns the element. So when the provider unmounts, React tears down the portals but the `bw-glass` element (and any modal `bw-glass-backdrop`) stays on `document.body`.

Reproduces in Storybook: open a popup, don't close it, switch to another story → the popup lingers.

## Fix

`useWindowlessGlass` already owns the add/remove lifecycle, so teardown belongs there:

- Track every live glass id in a ref (the portal map only holds *content-bearing* glasses, so it can't be the source of truth).
- `removeWindowlessGlass` discards its id, so a normally-closed glass isn't double-removed.
- An unmount `useEffect` removes any survivors with `animateClose: false`.

`animateClose: false` is deliberate — bwin's animated close waits on `animationend`, which may never fire once React has unmounted the subtree. The synchronous path also removes the modal backdrop, so modals are cleaned up too.