### PR TITLE
feat: sync pane-content portals across detach/attach/close

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,12 @@ pnpm build
 cd examples/dashboard
 pnpm dev
 ```
+
+## Developing against a local bwin
+
+`react-bwin` consumes bwin's **built** output (`dist/bwin.js`). To develop both repos
+together, see bwin's
+[CONTRIBUTING](https://github.com/bhjsdev/bwin/blob/main/CONTRIBUTING.md#working-with-react-bwin)
+for the link + watch workflow.
+
+Note: bwin ships no types; keep the `src/bwin.d.ts` shim in sync when its API changes.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Full guides, API reference, and live examples: [bhjsdev.github.io/bwin-docs](htt
 ### Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local development and how to run the examples.
+
+### Related
+
+- [bwin](https://github.com/bhjsdev/bwin) — the underlying window-tiling engine this binds to.

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -16,6 +16,7 @@ const links = [
   're-render',
   'theme',
   'window-provider',
+  'window-unmount',
   'windowless-glass',
   'windowless-glass-unmount',
 ].sort()

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -17,7 +17,7 @@ const links = [
   'theme',
   'window-provider',
   'windowless-glass',
-  'detached-glass-unmount',
+  'windowless-glass-unmount',
 ].sort()
 
 const components: Record<string, FunctionComponent> = {}

--- a/dev/window-unmount.tsx
+++ b/dev/window-unmount.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Window } from '../src'
+
+// Detached-glass teardown when the Window itself unmounts — no WindowProvider.
+// A glass detached from the window (the ☐ action) is appended INSIDE the
+// bw-window element, which React owns, so unmounting the Window removes it too.
+// Detach a pane, then untick the checkbox: nothing should linger on the page.
+export default function App() {
+  const [mounted, setMounted] = React.useState(true)
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Window — unmount cleanup</h2>
+      <ol>
+        <li>
+          Detach a pane from the window with its <b>☐</b> action.
+        </li>
+        <li>
+          Without closing it, untick <b>Mount Window</b>.
+        </li>
+        <li>
+          The detached glass should disappear with the window. Anything left on
+          the page is an orphaned glass.
+        </li>
+      </ol>
+      <label style={{ display: 'block', margin: '12px 0' }}>
+        <input
+          type="checkbox"
+          checked={mounted}
+          onChange={(e) => setMounted(e.target.checked)}
+        />{' '}
+        Mount Window
+      </label>
+      {mounted ? (
+        <Window
+          width={444}
+          height={300}
+          panes={[
+            {
+              size: 0.5,
+              position: 'left',
+              title: 'Pane 1',
+              content: <div style={{ padding: 8 }}>Detach me with ☐</div>,
+            },
+            {
+              title: 'Pane 2',
+              content: <div style={{ padding: 8 }}>Detach me with ☐</div>,
+            },
+          ]}
+        />
+      ) : (
+        <i>Window unmounted — no glass should remain on the page.</i>
+      )}
+    </div>
+  )
+}

--- a/dev/windowless-glass-unmount.tsx
+++ b/dev/windowless-glass-unmount.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Window, WindowProvider, useWindow } from '../src'
+
+export default function App() {
+  const [mounted, setMounted] = React.useState(true)
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Detached glass — unmount cleanup</h2>
+      <ol>
+        <li>Open a windowless glass</li>
+        <li>
+          Without closing anything, untick <b>Mount WindowProvider</b>.
+        </li>
+        <li>
+          Everything should disappear. Anything left on the page is an orphaned
+          glass.
+        </li>
+      </ol>
+      <label style={{ display: 'block', margin: '12px 0' }}>
+        <input
+          type="checkbox"
+          checked={mounted}
+          onChange={(e) => setMounted(e.target.checked)}
+        />{' '}
+        Mount WindowProvider
+      </label>
+      {mounted ? (
+        <WindowProvider>
+          <Main />
+        </WindowProvider>
+      ) : (
+        <i>Provider unmounted — no glass should remain on the page.</i>
+      )}
+    </div>
+  )
+}
+
+function Main() {
+  const { addWindowlessGlass } = useWindow()
+  const counter = React.useRef(0)
+
+  function handleOpen() {
+    const n = ++counter.current
+    addWindowlessGlass({
+      title: `Glass ${n}`,
+      content: <div style={{ padding: 8 }}>windowless {n}</div>,
+    })
+  }
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <button onClick={handleOpen}>Add windowless</button>
+    </div>
+  )
+}

--- a/dev/windowless-glass.tsx
+++ b/dev/windowless-glass.tsx
@@ -29,6 +29,16 @@ function Main() {
     })
   }
 
+  // Modal whose backdrop closes the glass on click (`closeOnBackdropClick`).
+  function handleModalCloseOnBackdrop() {
+    addWindowlessGlass({
+      modal: true,
+      closeOnBackdropClick: true,
+      title: 'Click backdrop to close',
+      content: <div style={{ padding: 8 }}>click outside to close</div>,
+    })
+  }
+
   // Placed relative to the body's top-left via offsetX/offsetY.
   function handlePositioned() {
     addWindowlessGlass({
@@ -70,6 +80,9 @@ function Main() {
       <h2>Windowless glass</h2>
       <button onClick={handleBasic}>Add windowless</button>
       <button onClick={handleModal}>Add modal</button>
+      <button onClick={handleModalCloseOnBackdrop}>
+        Add modal (close on backdrop)
+      </button>
       <button onClick={handlePositioned}>Add positioned</button>
       <button onClick={handleFullscreen}>Add fullscreen</button>
       <button onClick={handleNonResizable}>Add non-resizable</button>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.5.1-dev-bd61257",
+    "bwin": "0.5.1-dev-fc6b142",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.5.1-dev-fc6b142",
+    "bwin": "^0.6.0",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "0.5.0",
+    "bwin": "0.5.1-dev-bd61257",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.5.1-dev-bd61257
-        version: 0.5.1-dev-bd61257
+        specifier: 0.5.1-dev-fc6b142
+        version: 0.5.1-dev-fc6b142
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.5.1-dev-bd61257:
-    resolution: {integrity: sha512-nSzLodaPovRttmXS772x5IULV284rPZoXpo6s7/yAuX8cK1Vv2rE0F8ruo7JagK+5gqLXkNrF3Is/disSnOQHg==}
+  bwin@0.5.1-dev-fc6b142:
+    resolution: {integrity: sha512-2xB+3DvvxK7h+J9VoxPLFPTnH0UCbDa3bLkThOqf1zsP69Pkcx5+vsx4EaziwAHCJtrrCTSfGKANFEsnc64yxQ==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.5.1-dev-bd61257: {}
+  bwin@0.5.1-dev-fc6b142: {}
 
   csstype@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.5.1-dev-fc6b142
-        version: 0.5.1-dev-fc6b142
+        specifier: ^0.6.0
+        version: 0.6.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.5.1-dev-fc6b142:
-    resolution: {integrity: sha512-2xB+3DvvxK7h+J9VoxPLFPTnH0UCbDa3bLkThOqf1zsP69Pkcx5+vsx4EaziwAHCJtrrCTSfGKANFEsnc64yxQ==}
+  bwin@0.6.0:
+    resolution: {integrity: sha512-/Yt1Aej88vl870yPPdkL/LAYNVTOfyiA0Zch871/ZqGqb/dFf/9pNq+3w6IZw1FvqrrJDOgUa4gSCFZJ2cUoaA==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.5.1-dev-fc6b142: {}
+  bwin@0.6.0: {}
 
   csstype@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1-dev-bd61257
+        version: 0.5.1-dev-bd61257
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.5.0:
-    resolution: {integrity: sha512-1ItX2ruHcrNCUVqBh8E+ENH3hnHPMgezakoUB20WwijQI1W8gD79C7XegDqr2rirAJ1ZaNLOx8axEoCykzTxVA==}
+  bwin@0.5.1-dev-bd61257:
+    resolution: {integrity: sha512-nSzLodaPovRttmXS772x5IULV284rPZoXpo6s7/yAuX8cK1Vv2rE0F8ruo7JagK+5gqLXkNrF3Is/disSnOQHg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.5.0: {}
+  bwin@0.5.1-dev-bd61257: {}
 
   csstype@3.2.3: {}
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -99,6 +99,7 @@ declare global {
 
   type WindowlessGlassOptions = {
     modal?: boolean
+    closeOnBackdropClick?: boolean
     position?: WindowlessGlassPosition
     width?: number
     height?: number
@@ -112,11 +113,11 @@ declare global {
     tabs?: object[]
     draggable?: boolean
     resizable?: boolean
-    animateOpen?: boolean
+    animate?: boolean
   }
 
   type RemoveWindowlessGlassOptions = {
-    animateClose?: boolean
+    animate?: boolean
   }
 
   interface BinaryWindow {
@@ -134,11 +135,11 @@ declare global {
     updatePane(sashId: string, fields: UpdatePaneOptions): void
     removePane(sashId: string): void
     setTheme(theme: string): void
-    addWindowlessGlass(options?: WindowlessGlassOptions): HTMLElement
+    addWindowlessGlass(options?: WindowlessGlassOptions): Promise<HTMLElement>
     removeWindowlessGlass(
       windowlessGlassId: string,
       options?: RemoveWindowlessGlassOptions
-    ): HTMLElement | null
+    ): Promise<HTMLElement | null>
   }
 
   type WindowApi = {
@@ -152,11 +153,13 @@ declare global {
   // Windowless glass lives on the WindowProvider (static BinaryWindow methods,
   // no owning window), so its API is separate from the per-Window WindowApi.
   type WindowlessGlassApi = {
-    addWindowlessGlass: (options?: WindowlessGlassOptions) => HTMLElement
+    addWindowlessGlass: (
+      options?: WindowlessGlassOptions
+    ) => Promise<HTMLElement>
     removeWindowlessGlass: (
       windowlessGlassId: string,
       options?: RemoveWindowlessGlassOptions
-    ) => HTMLElement | null
+    ) => Promise<void>
   }
 
   /**

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -90,6 +90,29 @@ declare global {
 
   type UpdatePaneOptions = Omit<PaneFields, 'id' | 'actions'>
 
+  // Per-instance event emitter (bwin `frame/event.js`). Pane-lifecycle events
+  // carry the affected `Sash`; glass-action events carry the `<bw-glass>` element.
+  // Only `before-*` events are vetoable — a listener returning `false` cancels.
+  type BinaryWindowEventMap = {
+    'before-pane-add': Sash
+    'pane-add': Sash
+    'before-pane-remove': Sash
+    'pane-remove': Sash
+    close: HTMLElement
+    minimize: HTMLElement
+    maximize: HTMLElement
+    unmaximize: HTMLElement
+    detach: HTMLElement
+    attach: HTMLElement
+    restore: HTMLElement
+  }
+
+  type BinaryWindowEvent = keyof BinaryWindowEventMap
+
+  type BinaryWindowEventListener<E extends BinaryWindowEvent> = (
+    detail: BinaryWindowEventMap[E]
+  ) => void | boolean
+
   type WindowlessGlassPosition =
     | 'center'
     | 'top-left'
@@ -135,6 +158,14 @@ declare global {
     updatePane(sashId: string, fields: UpdatePaneOptions): void
     removePane(sashId: string): void
     setTheme(theme: string): void
+    on<E extends BinaryWindowEvent>(
+      eventName: E,
+      listener: BinaryWindowEventListener<E>
+    ): void
+    off<E extends BinaryWindowEvent>(
+      eventName: E,
+      listener: BinaryWindowEventListener<E>
+    ): void
     addWindowlessGlass(options?: WindowlessGlassOptions): Promise<HTMLElement>
     removeWindowlessGlass(
       windowlessGlassId: string,

--- a/src/usePaneContentPortals.ts
+++ b/src/usePaneContentPortals.ts
@@ -83,6 +83,70 @@ export default function usePaneContentPortals(
     }
 
     setPaneContentPortals(initial)
+
+    // Detach/attach destroy the old owner (the source pane on detach, the
+    // detached glass on attach) and create a new one with a fresh id, so the
+    // portal key — which names that owner — goes stale. bwin's `transferGlass`
+    // moves the `bw-glass-content` element itself between them, so the container
+    // is the one constant that rides through. Find the entry by that surviving
+    // container and re-key it to the new owner so lookups (portal key,
+    // updatePane, close) keep resolving and the content stays mounted.
+    function rekeyPortalByContainer(glassEl: HTMLElement, newKey: string) {
+      const contentEl = glassEl.querySelector('bw-glass-content')
+      if (!contentEl) return
+
+      setPaneContentPortals((prev) => {
+        for (const [key, portal] of prev) {
+          if (portal.container !== contentEl) continue
+          if (key === newKey) return prev
+
+          const next = new Map(prev)
+          next.delete(key)
+          next.set(newKey, portal)
+          return next
+        }
+        return prev
+      })
+    }
+
+    // Detached glass owns the content now; key by the detached glass id.
+    function handleDetach(detachedGlassEl: HTMLElement) {
+      rekeyPortalByContainer(detachedGlassEl, detachedGlassEl.id)
+    }
+
+    // Re-attached into a freshly-built pane; key by that pane's new sash id.
+    function handleAttach(glassEl: HTMLElement) {
+      const paneSashId = glassEl.closest('bw-pane')?.getAttribute('sash-id')
+      if (paneSashId) rekeyPortalByContainer(glassEl, paneSashId)
+    }
+
+    // Close destroys the glass (attached or detached) — drop its portal. The
+    // built-in close action calls removePane/removeDetachedGlass directly,
+    // bypassing the wrapper's removePane, so prune by the moved container here.
+    function handleClose(glassEl: HTMLElement) {
+      const contentEl = glassEl.querySelector('bw-glass-content')
+      if (!contentEl) return
+
+      setPaneContentPortals((prev) => {
+        for (const [key, portal] of prev) {
+          if (portal.container !== contentEl) continue
+          const next = new Map(prev)
+          next.delete(key)
+          return next
+        }
+        return prev
+      })
+    }
+
+    bwin.on('detach', handleDetach)
+    bwin.on('attach', handleAttach)
+    bwin.on('close', handleClose)
+
+    return () => {
+      bwin.off('detach', handleDetach)
+      bwin.off('attach', handleAttach)
+      bwin.off('close', handleClose)
+    }
   }, [])
 
   return {

--- a/src/useWindowlessGlass.ts
+++ b/src/useWindowlessGlass.ts
@@ -12,9 +12,9 @@ export default function useWindowlessGlass() {
 
   const liveGlassIdsRef = useRef<Set<string>>(new Set())
 
-  function addWindowlessGlass(options: WindowlessGlassOptions = {}) {
+  async function addWindowlessGlass(options: WindowlessGlassOptions = {}) {
     const { content, ...rest } = options
-    const glassEl = BinaryWindow.addWindowlessGlass(rest)
+    const glassEl = await BinaryWindow.addWindowlessGlass(rest)
 
     liveGlassIdsRef.current.add(glassEl.id)
 
@@ -22,6 +22,7 @@ export default function useWindowlessGlass() {
       const contentEl = glassEl.querySelector('bw-glass-content')
 
       if (contentEl) {
+        // There's a delay to show content due to the opening animation
         setWindowlessGlassPortals((prev) =>
           new Map(prev).set(glassEl.id, {
             node: content,
@@ -34,14 +35,12 @@ export default function useWindowlessGlass() {
     return glassEl
   }
 
-  function removeWindowlessGlass(
+  async function removeWindowlessGlass(
     windowlessGlassId: string,
     options?: RemoveWindowlessGlassOptions
   ) {
-    const removed = BinaryWindow.removeWindowlessGlass(
-      windowlessGlassId,
-      options
-    )
+    await BinaryWindow.removeWindowlessGlass(windowlessGlassId, options)
+
     liveGlassIdsRef.current.delete(windowlessGlassId)
 
     setWindowlessGlassPortals((prev) => {
@@ -51,8 +50,6 @@ export default function useWindowlessGlass() {
       next.delete(windowlessGlassId)
       return next
     })
-
-    return removed
   }
 
   // A windowless glass lives on document.body, outside React's tree. Without
@@ -62,9 +59,9 @@ export default function useWindowlessGlass() {
 
     return () => {
       liveGlassIds.forEach((id) =>
-        BinaryWindow.removeWindowlessGlass(id, { animateClose: false })
+        BinaryWindow.removeWindowlessGlass(id, { animate: false })
       )
-      
+
       liveGlassIds.clear()
     }
   }, [])


### PR DESCRIPTION
## What

- Sync pane-content portals across detach / attach / close so React-owned content stays mounted as bwin moves the `bw-glass-content` element between owners (re-keys the portal by its surviving container).
- Remove windowless glasses (and their content portals) when `WindowProvider` unmounts, so nothing is orphaned on `document.body`.
- Upgrade `bwin` to `^0.6.0` and widen the windowless-glass types in `src/global.d.ts`.
- Dev pages exercising the unmount + windowless-glass flows.
- Docs: add a **Developing against a local bwin** section to `CONTRIBUTING.md` (pointing to bwin's contributing guide) and a **Related** link to the bwin repo in the README.

## Test plan

- `dev/windowless-glass-unmount.tsx` — open a windowless glass, unmount the provider → no orphaned glass remains.
- `dev/window-unmount.tsx` — unmount with panes open → content portals torn down cleanly.
- Detach a pane, re-attach it, close it → content stays mounted through detach/attach and is dropped on close.