### PR TITLE
fix: restore bw-action-type on bar buttons so detach skips builtins

### DIFF
--- a/src/Pane.tsx
+++ b/src/Pane.tsx
@@ -87,6 +87,7 @@ export default function Pane({
                   <button
                     className={className}
                     key={key}
+                    bw-action-type={action.type || undefined}
                     onClick={(event) => action.onClick(event, bwin)}
                   >
                     {action.label}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,6 +16,7 @@ declare global {
 
   type Action = {
     id?: string
+    type?: string
     label?: string
     className?: string
     placement?: 'bar' | 'menu'


### PR DESCRIPTION
## Problem

When a glass is detached, it carries extra (builtin) action buttons.

## Root cause

PR #17 (`fix: action menu type`) dropped `bw-action-type={action.type || undefined}` from the bar-action button in `Pane.tsx` while renaming the `list`→`menu` placement and tightening types.

bwin's `transferGlass` (`src/binary-window/glass/utils.js:34`) carries only *custom* bar actions into the detached glass:

```js
const customActionEls = [...(sourceActionBarEl?.children ?? [])].filter(
  (actionEl) => !actionEl.getAttribute('bw-action-type')?.includes('builtin')
);
```

The producer side (`glass.js:120`) stamps the attribute: `if (action.type) buttonEl.setAttribute('bw-action-type', action.type)`. Builtin glass actions carry `type: "glass-builtin"`.

Without the attribute on react-bwin's rendered buttons, every bar button looked non-builtin, so bwin prepended the attached glass's builtin bar buttons onto the detached glass — which already has its own `DEFAULT_DETACHED_GLASS_ACTIONS`. Hence the duplicate buttons.

## Fix

- `src/Pane.tsx` — re-stamp `bw-action-type={action.type || undefined}` on the bar button so `transferGlass`'s builtin filter works again.
- `src/global.d.ts` — restore `type?: string` on the `Action` type (PR #17 had dropped the only usage).

Scoped to the bar only: `transferGlass` moves the action menu wholesale, so menu actions never used this filter.