### PR TITLE
ci: build package on pull requests and add status badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## React Binary Window
 
+[![Build](https://github.com/bhjsdev/react-bwin/actions/workflows/build.yml/badge.svg)](https://github.com/bhjsdev/react-bwin/actions/workflows/build.yml)
 [![Publish to npm](https://github.com/bhjsdev/react-bwin/actions/workflows/publish.yml/badge.svg)](https://github.com/bhjsdev/react-bwin/actions/workflows/publish.yml)
 [![npm version](https://img.shields.io/npm/v/react-bwin)](https://www.npmjs.com/package/react-bwin)
 


### PR DESCRIPTION
Adds a CI workflow that builds the package on every PR (opened, synchronize, reopened) and surfaces the result via a status badge in the README.

- `.github/workflows/build.yml` — runs `pnpm build` (tsc + vite) on PRs, mirroring `publish.yml`'s toolchain (pnpm 11, Node 24, frozen lockfile).
- README — adds a `Build` status badge above the publish badge.