### PR TITLE
feat: expose add/remove detached glass through WindowApi

### DIFF
--- a/dev/detached-glass.tsx
+++ b/dev/detached-glass.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { Window, WindowProvider, useWindow } from '../src'
+
+// Programmatic in-window detached glass via useWindow (mirrors the ☐ action, but
+// driven from React with portaled content). A detached glass floats INSIDE the
+// bw-window, unlike a windowless glass which floats on document.body.
+export default function App() {
+  return (
+    <WindowProvider>
+      <Main />
+    </WindowProvider>
+  )
+}
+
+function Main() {
+  const { addDetachedGlass, removeDetachedGlass } = useWindow()
+  const counter = React.useRef(0)
+  const lastIdRef = React.useRef<string | null>(null)
+
+  // No position/size: cascades down-right of the active detached glass.
+  async function handleAdd() {
+    const n = ++counter.current
+    const glassEl = await addDetachedGlass({
+      title: `Detached ${n}`,
+      content: <div style={{ padding: 8 }}>detached {n}</div>,
+    })
+    lastIdRef.current = glassEl.id
+  }
+
+  // Anchored to the window's top-left via offsetX/offsetY.
+  async function handleAddPositioned() {
+    const n = ++counter.current
+    const glassEl = await addDetachedGlass({
+      title: `Positioned ${n}`,
+      position: 'top-left',
+      offsetX: 40,
+      offsetY: 40,
+      content: <div style={{ padding: 8 }}>positioned {n}</div>,
+    })
+    lastIdRef.current = glassEl.id
+  }
+
+  // Fixed size with resize handles suppressed.
+  async function handleAddNonResizable() {
+    const n = ++counter.current
+    const glassEl = await addDetachedGlass({
+      title: `Non-resizable ${n}`,
+      width: 260,
+      height: 160,
+      resizable: false,
+      content: <div style={{ padding: 8 }}>non-resizable {n}</div>,
+    })
+    lastIdRef.current = glassEl.id
+  }
+
+  function handleRemoveLast() {
+    if (lastIdRef.current) {
+      removeDetachedGlass(lastIdRef.current)
+      lastIdRef.current = null
+    }
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Detached glass via useWindow</h2>
+      <div style={{ marginBottom: 12 }}>
+        <button onClick={handleAdd}>Add detached</button>
+        <button onClick={handleAddPositioned}>Add positioned</button>
+        <button onClick={handleAddNonResizable}>Add non-resizable</button>
+        <button onClick={handleRemoveLast}>Remove last</button>
+      </div>
+      <Window
+        width={555}
+        height={333}
+        panes={[
+          {
+            size: 0.5,
+            position: 'left',
+            title: 'Pane 1',
+            content: <div style={{ padding: 8 }}>Add a detached glass above</div>,
+          },
+          {
+            title: 'Pane 2',
+            content: <div style={{ padding: 8 }}>Detach me with ☐ too</div>,
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -13,6 +13,7 @@ const links = [
   'add-remove-panes',
   'custom-action',
   'custom-action-use-window',
+  'detached-glass',
   'events',
   're-render',
   'theme',

--- a/dev/window-unmount.tsx
+++ b/dev/window-unmount.tsx
@@ -7,13 +7,33 @@ import { Window } from '../src'
 // Detach a pane, then untick the checkbox: nothing should linger on the page.
 export default function App() {
   const [mounted, setMounted] = React.useState(true)
+  const windowRef = React.useRef<WindowApi>(null)
+  const counter = React.useRef(0)
+  const lastIdRef = React.useRef<string | null>(null)
+
+  // Programmatic detached glass (same INSIDE-the-window subtree as the ☐ action).
+  async function handleAddDetached() {
+    const n = ++counter.current
+    const glassEl = await windowRef.current!.addDetachedGlass({
+      title: `Detached ${n}`,
+      content: <div style={{ padding: 8 }}>detached {n}</div>,
+    })
+    lastIdRef.current = glassEl.id
+  }
+
+  function handleRemoveLast() {
+    if (lastIdRef.current) {
+      windowRef.current!.removeDetachedGlass(lastIdRef.current)
+      lastIdRef.current = null
+    }
+  }
 
   return (
     <div style={{ padding: 20 }}>
       <h2>Window — unmount cleanup</h2>
       <ol>
         <li>
-          Detach a pane from the window with its <b>☐</b> action.
+          Detach a pane with its <b>☐</b> action, or use <b>Add detached</b>.
         </li>
         <li>
           Without closing it, untick <b>Mount Window</b>.
@@ -23,6 +43,14 @@ export default function App() {
           the page is an orphaned glass.
         </li>
       </ol>
+      <div style={{ margin: '12px 0' }}>
+        <button onClick={handleAddDetached} disabled={!mounted}>
+          Add detached
+        </button>
+        <button onClick={handleRemoveLast} disabled={!mounted}>
+          Remove last
+        </button>
+      </div>
       <label style={{ display: 'block', margin: '12px 0' }}>
         <input
           type="checkbox"
@@ -33,6 +61,7 @@ export default function App() {
       </label>
       {mounted ? (
         <Window
+          ref={windowRef}
           width={444}
           height={300}
           panes={[

--- a/src/Window.tsx
+++ b/src/Window.tsx
@@ -33,8 +33,14 @@ export default forwardRef<WindowApi, WindowProps>((props, ref) => {
     }
   })
 
-  const { paneContentPortals, addPane, updatePane, removePane } =
-    usePaneContentPortals(bwin, windowRef, panes)
+  const {
+    paneContentPortals,
+    addPane,
+    updatePane,
+    removePane,
+    addDetachedGlass,
+    removeDetachedGlass,
+  } = usePaneContentPortals(bwin, windowRef, panes)
 
   useEffect(() => {
     const windowEl = windowRef.current
@@ -55,6 +61,8 @@ export default forwardRef<WindowApi, WindowProps>((props, ref) => {
       addPane,
       removePane,
       updatePane,
+      addDetachedGlass,
+      removeDetachedGlass,
       on: bwin.on.bind(bwin),
       off: bwin.off.bind(bwin),
     }),
@@ -74,6 +82,8 @@ export default forwardRef<WindowApi, WindowProps>((props, ref) => {
       addPane,
       removePane,
       updatePane,
+      addDetachedGlass,
+      removeDetachedGlass,
       on: bwin.on.bind(bwin),
       off: bwin.off.bind(bwin),
     }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -144,6 +144,27 @@ declare global {
     animate?: boolean
   }
 
+  // A detached glass floats inside a `bw-window`; positions match windowless glass.
+  type DetachedGlassOptions = {
+    position?: WindowlessGlassPosition
+    width?: number
+    height?: number
+    offset?: number
+    offsetX?: number
+    offsetY?: number
+    id?: string
+    actions?: Actions
+    title?: React.ReactNode
+    content?: React.ReactNode
+    draggable?: boolean
+    resizable?: boolean
+    animate?: boolean
+  }
+
+  type RemoveDetachedGlassOptions = {
+    animate?: boolean
+  }
+
   interface BinaryWindow {
     new(settings: ConfigRoot): BinaryWindow
     rootSash: Sash
@@ -158,6 +179,11 @@ declare global {
     addPane(targetPaneSashId: string, fields: PaneFields): Sash
     updatePane(sashId: string, fields: UpdatePaneOptions): void
     removePane(sashId: string): void
+    addDetachedGlass(options?: DetachedGlassOptions): Promise<HTMLElement>
+    removeDetachedGlass(
+      id: string,
+      options?: RemoveDetachedGlassOptions
+    ): Promise<HTMLElement | null>
     setTheme(theme: string): void
     on<E extends BinaryWindowEvent>(
       eventName: E,
@@ -178,6 +204,13 @@ declare global {
     addPane: (targetPaneSashId: string, fields: PaneFields) => void
     updatePane: (sashId: string, fields: UpdatePaneOptions) => void
     removePane: (sashId: string) => void
+    addDetachedGlass: (
+      options?: DetachedGlassOptions
+    ) => Promise<HTMLElement>
+    removeDetachedGlass: (
+      id: string,
+      options?: RemoveDetachedGlassOptions
+    ) => Promise<HTMLElement | null>
     fit: () => void
     setTheme: (theme: string) => void
     on: <E extends BinaryWindowEvent>(

--- a/src/usePaneContentPortals.ts
+++ b/src/usePaneContentPortals.ts
@@ -64,6 +64,45 @@ export default function usePaneContentPortals(
     })
   }
 
+  // A detached glass floats INSIDE the bw-window (React owns that subtree), so
+  // its content portals through the same map as panes, keyed by the glass id.
+  async function addDetachedGlass(options: DetachedGlassOptions = {}) {
+    const { content, ...rest } = options
+    const glassEl = await bwin.addDetachedGlass(rest)
+
+    if ('content' in options) {
+      const glassContentEl = glassEl.querySelector('bw-glass-content')
+
+      if (glassContentEl) {
+        setPaneContentPortals((prev) =>
+          new Map(prev).set(glassEl.id, {
+            node: content,
+            container: glassContentEl as HTMLElement,
+          })
+        )
+      }
+    }
+
+    return glassEl
+  }
+
+  async function removeDetachedGlass(
+    id: string,
+    options?: RemoveDetachedGlassOptions
+  ) {
+    const removedGlassEl = await bwin.removeDetachedGlass(id, options)
+
+    setPaneContentPortals((prev) => {
+      if (!prev.has(id)) return prev
+
+      const next = new Map(prev)
+      next.delete(id)
+      return next
+    })
+
+    return removedGlassEl
+  }
+
   // Seed each pane's initial content into a portal before paint (avoids a flash
   // of empty panes).
   useLayoutEffect(() => {
@@ -158,5 +197,7 @@ export default function usePaneContentPortals(
     addPane,
     updatePane,
     removePane,
+    addDetachedGlass,
+    removeDetachedGlass,
   }
 }


### PR DESCRIPTION
Adds a programmatic React API for in-window detached glass, mirroring bwin's `addDetachedGlass` / `removeDetachedGlass` instance methods (alongside `addPane`). A detached glass floats *inside* the `bw-window` — distinct from the provider-scoped windowless glass.

## What changed
- **`usePaneContentPortals.ts`** — `addDetachedGlass(options)` / `removeDetachedGlass(id, options)`, reusing the existing pane-content portal map (keyed by glass id, so detach/attach/close rekey handling applies for free).
- **`Window.tsx`** — exposed both on the ref `WindowApi` and the provider `windowApi.current` (the `useWindow` Proxy auto-forwards them).
- **`global.d.ts`** — `DetachedGlassOptions`, `RemoveDetachedGlassOptions`, and the methods on `BinaryWindow` + `WindowApi`.
- **`dev/detached-glass.tsx`** — new demo page (cascade / positioned / non-resizable / remove).
- **`dev/window-unmount.tsx`** — add/remove buttons to exercise the ref-based (no-provider) path and unmount cleanup.