### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-bwin",
   "description": "A tiling window manager in React based on Binary Window library",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `package.json` version from 0.7.0 to 0.7.1.