### PR TITLE
ci: fail dev-publish guard on version bump for visibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,15 +97,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Decides whether dev-publish should run. A version bump means a formal release is
-  # being prepared, so a dev pre-release would be wrong — skip it.
+  # Fails on a version-bump merge so the run shows red, not a misleading green tick.
+  # dev-publish is skipped automatically via its failed `needs`.
   check-dev-publish:
     if: >-
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
       (github.event_name == 'workflow_dispatch' && inputs.dev_release == true)
     runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.guard.outputs.skip }}
 
     steps:
       - name: Check out repository
@@ -113,22 +111,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect version bump
-        id: guard
+      - name: Fail if the merged PR bumped the version
         if: github.event_name == 'pull_request'
         run: |
           head_ver="$(node -p "require('./package.json').version")"
           git show "${{ github.event.pull_request.base.sha }}:package.json" > /tmp/base-package.json
           base_ver="$(node -p "require('/tmp/base-package.json').version")"
           if [ "$base_ver" != "$head_ver" ]; then
-            echo "::notice::package.json version changed ($base_ver -> $head_ver); skipping dev publish."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::error::package.json version changed ($base_ver -> $head_ver) — dev publish skipped."
+            exit 1
           fi
 
   # Ungated (no `environment:`): auto on merge to main, or manual via `dev_release`.
   dev-publish:
     needs: check-dev-publish
-    if: needs.check-dev-publish.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Converts the `check-dev-publish` guard from a silent skip into a hard failure when a merged PR bumped `package.json`'s version.

- The guard now emits an `::error::` annotation and `exit 1` instead of a `::notice::` + `skip=true` output.
- Removed the now-unused `outputs.skip` and the `if: needs.check-dev-publish.outputs.skip != 'true'` gate on `dev-publish` — a failed `needs` skips it automatically.

## Why

A version-bump merge previously produced a **green tick** in the Actions list (skipped jobs roll up to success), which reads as "published OK" when nothing published. GitHub only renders **fail (red)** or **cancel (grey)** as non-green; failing is the simplest signal with no token or extra permissions. The run now shows red with the reason in the annotation, and no dev pre-release is cut.

Mirrors bhjsdev/bwin#120.