### PR TITLE
feat: expose setDetachedGlassBaseZIndex through useWindow

### DIFF
--- a/dev/detached-glass-base-zindex.tsx
+++ b/dev/detached-glass-base-zindex.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Window, WindowProvider, useWindow } from '../src'
+
+// Exercises useWindow().setDetachedGlassBaseZIndex. The manager is a shared
+// singleton, so setting the base affects the NEXT glass raised, not existing ones:
+// set a large base, then add a glass and watch it jump above the earlier ones.
+export default function App() {
+  return (
+    <WindowProvider>
+      <Main />
+    </WindowProvider>
+  )
+}
+
+function Main() {
+  const { addDetachedGlass, setDetachedGlassBaseZIndex } = useWindow()
+  const counter = React.useRef(0)
+  const [baseZIndex, setBaseZIndex] = React.useState(1)
+
+  async function handleAdd() {
+    const n = ++counter.current
+    await addDetachedGlass({
+      title: `Detached ${n}`,
+      content: (
+        <div style={{ padding: 8 }}>
+          detached {n} — inspect z-index in devtools
+        </div>
+      ),
+    })
+  }
+
+  function handleSetBase() {
+    setDetachedGlassBaseZIndex(baseZIndex)
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Detached glass base z-index via useWindow</h2>
+      <div style={{ marginBottom: 12 }}>
+        <label>
+          base z-index{' '}
+          <input
+            type="number"
+            value={baseZIndex}
+            onChange={(e) => setBaseZIndex(Number(e.target.value))}
+          />
+        </label>
+        <button onClick={handleSetBase}>Set base z-index</button>
+        <button onClick={handleAdd}>Add detached</button>
+      </div>
+      <Window
+        width={555}
+        height={333}
+        panes={[
+          {
+            size: 0.5,
+            position: 'left',
+            title: 'Pane 1',
+            content: (
+              <div style={{ padding: 8 }}>
+                Add a few glasses, set a large base, then add another.
+              </div>
+            ),
+          },
+          {
+            title: 'Pane 2',
+            content: <div style={{ padding: 8 }}>Detach me with ☐ too</div>,
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -14,6 +14,7 @@ const links = [
   'custom-action',
   'custom-action-use-window',
   'detached-glass',
+  'detached-glass-base-zindex',
   'events',
   're-render',
   'theme',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^16.14.62",
     "@types/react-dom": "^16.9.24",
     "@vitejs/plugin-react": "^6.0.2",
-    "bwin": "^0.6.1",
+    "bwin": "0.6.2-dev-01e5b84",
     "picocolors": "^1.1.1",
     "prettier": "^3.4.1",
     "react": "^16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@24.13.1))
       bwin:
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: 0.6.2-dev-01e5b84
+        version: 0.6.2-dev-01e5b84
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -260,8 +260,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  bwin@0.6.1:
-    resolution: {integrity: sha512-4V9XextTWmpO/Kc7CCOW8cP/gloRMml0ALhZaz/TwvHl8EBEv4jO/S3xquMYIqqoBf9kV8HbFAtB2kdaGjezGg==}
+  bwin@0.6.2-dev-01e5b84:
+    resolution: {integrity: sha512-PuQk9/R5dJCQetxHXj/XAS6wiHSiqsif0K2ScvV0W7HLLWCih/pCwSWga0AgIhfF8/EDbN8xO/46piGJPKs+cg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -622,7 +622,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.1)
 
-  bwin@0.6.1: {}
+  bwin@0.6.2-dev-01e5b84: {}
 
   csstype@3.2.3: {}
 

--- a/src/WindowProvider.tsx
+++ b/src/WindowProvider.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
+import { detachedGlassManager } from 'bwin'
 import useWindowlessGlass from './useWindowlessGlass.ts'
 
 type WindowContextValue = {
   windowApi: React.MutableRefObject<WindowApi | null>
   windowlessApi: WindowlessGlassApi
+  detachedGlassManagerApi: DetachedGlassManagerApi
 }
 
 export const WindowContext = React.createContext<WindowContextValue | null>(
@@ -14,8 +16,6 @@ export const WindowContext = React.createContext<WindowContextValue | null>(
 export function WindowProvider({ children }: React.PropsWithChildren<{}>) {
   const windowApi = React.useRef<WindowApi | null>(null)
 
-  // Windowless glass uses static BinaryWindow methods and portals onto
-  // document.body, so it lives on the provider and works without a <Window>.
   const { windowlessGlassPortals, addWindowlessGlass, removeWindowlessGlass } =
     useWindowlessGlass()
 
@@ -24,8 +24,15 @@ export function WindowProvider({ children }: React.PropsWithChildren<{}>) {
     removeWindowlessGlass,
   }
 
+  const detachedGlassManagerApi: DetachedGlassManagerApi = {
+    setDetachedGlassBaseZIndex: (zIndex) =>
+      detachedGlassManager.setBaseZIndex(zIndex),
+  }
+
   return (
-    <WindowContext.Provider value={{ windowApi, windowlessApi }}>
+    <WindowContext.Provider
+      value={{ windowApi, windowlessApi, detachedGlassManagerApi }}
+    >
       {children}
       {[...windowlessGlassPortals].map(([glassId, { node, container }]) =>
         createPortal(node, container, glassId)
@@ -34,19 +41,23 @@ export function WindowProvider({ children }: React.PropsWithChildren<{}>) {
   )
 }
 
-export function useWindow(): WindowApi & WindowlessGlassApi {
+export function useWindow(): WindowApi &
+  WindowlessGlassApi &
+  DetachedGlassManagerApi {
   const context = React.useContext(WindowContext)
 
   if (!context) {
     throw new Error('useWindow must be used within a WindowProvider')
   }
 
-  const { windowApi, windowlessApi } = context
+  const { windowApi, windowlessApi, detachedGlassManagerApi } = context
+
+  type CombinedApi = WindowApi & WindowlessGlassApi & DetachedGlassManagerApi
 
   // Build the API once and lock its identity (via a ref, not useMemo: React may
   // discard a memo's cache, breaking identity stability) so it's stable in
   // consumer dependency arrays.
-  const apiRef = React.useRef<WindowApi & WindowlessGlassApi>()
+  const apiRef = React.useRef<CombinedApi>()
 
   if (!apiRef.current) {
     // A Proxy lets every WindowApi method work without listing it here. Reading
@@ -57,11 +68,16 @@ export function useWindow(): WindowApi & WindowlessGlassApi {
     //     -> get('addPane') returns (...args) => windowApi.current.addPane(...args)
     //     -> calls windowApi.current.addPane('a', {...}), or throws if not mounted
     //
-    // Windowless-glass methods live on the provider, so they're returned directly.
-    apiRef.current = new Proxy({} as WindowApi & WindowlessGlassApi, {
-      get(_target, key: keyof (WindowApi & WindowlessGlassApi)) {
+    // Windowless-glass and detached-glass-manager methods live on the provider,
+    // so they're returned directly.
+    apiRef.current = new Proxy({} as CombinedApi, {
+      get(_target, key: keyof CombinedApi) {
         if (key in windowlessApi) {
           return windowlessApi[key as keyof WindowlessGlassApi]
+        }
+
+        if (key in detachedGlassManagerApi) {
+          return detachedGlassManagerApi[key as keyof DetachedGlassManagerApi]
         }
 
         return (...args: unknown[]) => {

--- a/src/bwin.d.ts
+++ b/src/bwin.d.ts
@@ -3,6 +3,20 @@ declare module 'bwin' {
   export const DEFAULT_GLASS_ACTIONS: Action[]
   export const DEFAULT_DETACHED_GLASS_ACTIONS: Action[]
   export const BinaryWindow: BinaryWindow
+
+  interface DetachedGlassManager {
+    detachedGlassElements: HTMLElement[]
+    topZIndex: number
+    setBaseZIndex(zIndex: number): void
+    addDetachedGlass(options?: DetachedGlassOptions): HTMLElement
+    getDetachedGlassById(id: string): HTMLElement | null
+    getActiveDetachedGlass(): HTMLElement | null
+    bringToFront(glassEl: HTMLElement): number | undefined
+    removeDetachedGlass(id: string): HTMLElement | null
+    updateDetachedGlass(id: string, options: DetachedGlassOptions): never
+  }
+
+  export const detachedGlassManager: DetachedGlassManager
 }
 
 declare namespace JSX {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,7 +8,9 @@ declare module 'react-bwin' {
   export const WindowProvider: React.FunctionComponent<
     React.PropsWithChildren<{}>
   >
-  export function useWindow(): WindowApi & WindowlessGlassApi
+  export function useWindow(): WindowApi &
+    WindowlessGlassApi &
+    DetachedGlassManagerApi
 }
 
 declare global {
@@ -235,6 +237,12 @@ declare global {
     ) => Promise<void>
   }
 
+  // The detached-glass manager is a shared singleton (not per-window), so its API
+  // lives on the WindowProvider alongside WindowlessGlassApi.
+  type DetachedGlassManagerApi = {
+    setDetachedGlassBaseZIndex: (zIndex: number) => void
+  }
+
   /**
    * @deprecated Use {@link WindowApi} instead.
    */
@@ -256,4 +264,5 @@ export {
   BinaryWindow,
   WindowProps,
   WindowlessGlassApi,
+  DetachedGlassManagerApi,
 }


### PR DESCRIPTION
## Summary

Expose bwin's detached-glass base z-index control to React consumers via `useWindow()`.

## Changes

- **`src/WindowProvider.tsx`** — add a provider-level `DetachedGlassManagerApi` that forwards `setDetachedGlassBaseZIndex(zIndex)` to bwin's `detachedGlassManager.setBaseZIndex`; returned from `useWindow()` (direct-return path, like the windowless-glass API, since the manager is a shared singleton with no owning `<Window>`).
- **`src/bwin.d.ts`** — type the `DetachedGlassManager` class and export the `detachedGlassManager` singleton in the `bwin` module shim.
- **`src/global.d.ts`** — add the `DetachedGlassManagerApi` type and fold it into `useWindow()`'s return type.
- **`package.json` / `pnpm-lock.yaml`** — bump `bwin` to `0.6.2-dev-01e5b84`, the dev build that exports `detachedGlassManager`.
- **`dev/detached-glass-base-zindex.tsx`** — dev page with a base-z-index input + button to exercise the API.

Consumers: `const { setDetachedGlassBaseZIndex } = useWindow()`.